### PR TITLE
Update brew installation commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ $ slack chat send hello @slackbot --filter '.ts + "\n" + .channel' |
 ### Via `brew`:
 
 ```bash
-$ brew tap rockymadden/rockymadden/slack-cli
+$ brew tap rockymadden/rockymadden
+$ brew install rockymadden/rockymadden/slack-cli
 ```
 
 ### Via `curl`:


### PR DESCRIPTION
This updates the commands in the `brew` installation section to the ones proposed by @dancetrain in https://github.com/rockymadden/slack-cli/issues/56. I've verified these work after experiencing the same trouble and coming across the issue while attempting to find the correct commands.

Closes https://github.com/rockymadden/slack-cli/issues/56.