### PR TITLE
Fixes bug preventing file uploads in private/direct messages

### DIFF
--- a/src/slack
+++ b/src/slack
@@ -442,7 +442,7 @@ function fileupload() {
     *)
       local msg=$(\
         curl -s -X POST https://slack.com/api/files.upload \
-          ${channels:+ --form "channels=${channels}"} \
+          ${channels:+ --form-string "channels=${channels}"} \
           ${comment:+ --form "initial_comment=${comment}"} \
           ${_file:+ --form "file=@${_file}"} \
           ${_filename:+ --form "filename=${_filename}"} \


### PR DESCRIPTION
This pull request fixes a bug that currently prevents the program from uploading a file to a private/direct conversation.  The bug is caused by `curl` interpreting the `@username` format for the channel name to instead be another file to be uploaded, and is fixed by instead defining the channel to use the related `--form-string` curl flag, which is specifically designed to account for `@`.

Unfortunately, I'm not familiar enough with automated bash testing to write the corresponding test, so this pull request is not quite complete as is.