### PR TITLE
Remove brew tap, installing w/ fqn will tap repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ $ slack chat send \
 ### Via `brew`
 
 ```console
-$ brew tap rockymadden/rockymadden
 $ brew install rockymadden/rockymadden/slack-cli
 ```
 


### PR DESCRIPTION
No need to `brew tap` beforehand when installing via a fully qualified name