### PR TITLE
Support status expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ slack chat send hi @slackbot
 ---
 __100% Slack-based pomodoro example:__
 ```console
-$ alias pomodoro='f() { slack status edit --text="Pomodoro" --emoji=":tomato:" && slack snooze start --minutes="${1-60}" && slack reminder add "Pomodoro done!" $(date -v +${1-60}M "+%s") }; f'
+$ alias pomodoro='f() { slack status edit --text="Pomodoro" --emoji=":tomato:" --expiration $(date -v +${1-60}M "+%s") && slack snooze start --minutes="${1-60}" && slack reminder add "Pomodoro done!" $(date -v +${1-60}M "+%s") }; f'
 $ pomodoro 60
 ```
 
@@ -359,10 +359,10 @@ $ # Edit status via arguments:
 $ slack status edit lunch :hamburger:
 $
 $ # Edit status via options:
-$ slack status edit --text lunch --emoji :hamburger:
+$ slack status edit --text lunch --emoji :hamburger: --expiration $(date -v 1H "+%s")
 $
 $ # Edit status via short form options:
-$ slack status edit --tx lunch -em :hamburger:
+$ slack status edit -tx lunch -em :hamburger: -ex $(date -v 1H "+%s")
 ```
 
 ## Contributors

--- a/src/slack
+++ b/src/slack
@@ -57,6 +57,8 @@ while (( "$#" )); do
     --count|-cn*) count=${2} ; shift ; shift ;;
     --emoji=*) emoji=${1/--emoji=/''} ; shift ;;
     --emoji*|-em*) emoji=${2} ; shift ; shift ;;
+    --expiration=*) expiration=${1/--expiration=/''} ; shift ;;
+    --expiration*|-ex*) expiration=${2} ; shift ; shift ;;
     --fields=*) fields=${1/--fields=/''} ; shift ;;
     --fields*|-flds*) fields=${2} ; shift ; shift ;;
     --filename=*) filename=${1/--filename=/''} ; shift ;;
@@ -135,6 +137,7 @@ while (( "$#" )); do
         ;;
         statusedit)
           [ -n "${1}" ] && [ -n "${text}" ] && [ -z "${emoji}" ] && emoji=${1}
+          [ -n "${1}" ] && [ -n "${text}" ] && [ -z "${expiration}" ] && expiration=${1}
           [ -n "${1}" ] && [ -z "${text}" ] && text=${1}
         ;;
         reminderadd)
@@ -217,6 +220,7 @@ case "${cmd}${sub}" in
   statusedit)
     [ -z "${text}" ] && read -e -p 'Enter text (e.g. lunch): ' text
     [ -z "${emoji}" ] && read -e -p 'Enter emoji (e.g. :hamburger:): ' emoji
+    [ -z "${expiration}" ] && read -e -p 'Enter timestamp (e.g. 1405894322): ' expiration
   ;;
 esac
 
@@ -407,7 +411,7 @@ function help() {
   echo "  ${bin} status clear"
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
   echo
-  echo "  ${bin} status edit [<text> [<emoji>]]"
+  echo "  ${bin} status edit [<text> [<emoji>] [<expiration>]]"
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
   echo
   echo 'Configuration Commands:'
@@ -640,7 +644,7 @@ function snoozestart() {
 function statusclear() {
   local msg=$(\
     curl -s -X POST https://slack.com/api/users.profile.set \
-      --data-urlencode 'profile={"status_text":"", "status_emoji":""}' \
+      --data-urlencode 'profile={"status_text":"", "status_emoji":"", "status_expiration":0}' \
       --data-urlencode "token=${token}")
 
   jqify "${msg}"
@@ -649,7 +653,7 @@ function statusclear() {
 function statusedit() {
   local msg=$(\
     curl -s -X POST https://slack.com/api/users.profile.set \
-      --data-urlencode "profile={\"status_text\":\"${text}\", \"status_emoji\":\"${emoji}\"}" \
+      --data-urlencode "profile={\"status_text\":\"${text}\", \"status_emoji\":\"${emoji}\", \"status_expiration\":\"${expiration}\"}" \
       --data-urlencode "token=${token}")
 
   jqify "${msg}"


### PR DESCRIPTION
Slack supports expiring a given status since around late August/early September. It's a nice way to communicate your activities if you know how long they take.