### PR TITLE
Allow user id lookup via email

### DIFF
--- a/src/slack
+++ b/src/slack
@@ -252,10 +252,10 @@ function jqify() {
 
 function lchannel() {
   case "${channel}" in
-    @*)
+    *@*)
       local _user=$(\
         curl -s -X POST https://slack.com/api/users.list --data-urlencode "token=${token}" 2>&1 | \
-        jq -r ".members | map(select(.name == \"${channel/@/}\" or .profile.display_name == \"${channel/@/}\")) | .[0].id")
+        jq -r ".members | map(select(.name == \"${channel/@/}\" or .profile.display_name == \"${channel/@/}\" or .profile.email == \"${channel}\")) | .[0].id")
       local _channel=$(\
         curl -s -X POST https://slack.com/api/im.list --data-urlencode "token=${token}" 2>&1 | \
         jq -r ".ims | map(select(.user == \"${_user}\")) | .[].id")
@@ -268,10 +268,10 @@ function lchannel() {
 
 function luser() {
   case "${user}" in
-    @*)
+    *@*)
       local _user=$(\
         curl -s -X POST https://slack.com/api/users.list --data-urlencode "token=${token}" 2>&1 | \
-        jq -r ".members | map(select(.name == \"${user/@/}\" or .profile.display_name == \"${user/@/}\")) | .[0].id")
+        jq -r ".members | map(select(.name == \"${user/@/}\" or .profile.display_name == \"${user/@/}\" or .profile.email == \"${user}\")) | .[0].id")
 
       echo ${_user}
     ;;

--- a/src/slack
+++ b/src/slack
@@ -254,11 +254,21 @@ function lchannel() {
   case "${channel}" in
     *@*)
       local _user=$(\
-        curl -s -X POST https://slack.com/api/users.list --data-urlencode "token=${token}" 2>&1 | \
-        jq -r ".members | map(select(.name == \"${channel/@/}\" or .profile.display_name == \"${channel/@/}\" or .profile.email == \"${channel}\")) | .[0].id")
+        curl -s -X POST https://slack.com/api/users.lookupByEmail --data-urlencode "token=${token}" --data-urlencode "email=${channel}" 2>&1 | \
+        jq -r ".user.id")
       local _channel=$(\
-        curl -s -X POST https://slack.com/api/im.list --data-urlencode "token=${token}" 2>&1 | \
-        jq -r ".ims | map(select(.user == \"${_user}\")) | .[].id")
+        curl -s -X POST https://slack.com/api/im.open --data-urlencode "token=${token}" --data-urlencode "user=${_user}" 2>&1 | \
+        jq -r ".channel.id")
+
+      echo ${_channel}
+    ;;
+    @*)
+      local _user=$(\
+        curl -s -X POST https://slack.com/api/users.list --data-urlencode "token=${token}" 2>&1 | \
+        jq -r ".members | map(select(.name == \"${channel/@/}\" or .profile.display_name == \"${channel/@/}\")) | .[0].id")
+      local _channel=$(\
+        curl -s -X POST https://slack.com/api/im.open --data-urlencode "token=${token}" --data-urlencode "user=${_user}" 2>&1 | \
+        jq -r ".channel.id")
 
       echo ${_channel}
     ;;
@@ -270,8 +280,15 @@ function luser() {
   case "${user}" in
     *@*)
       local _user=$(\
+        curl -s -X POST https://slack.com/api/users.lookupByEmail --data-urlencode "token=${token}" --data-urlencode "email=${user}" 2>&1 | \
+        jq -r ".user.id")
+
+      echo ${_user}
+    ;;
+    @*)
+      local _user=$(\
         curl -s -X POST https://slack.com/api/users.list --data-urlencode "token=${token}" 2>&1 | \
-        jq -r ".members | map(select(.name == \"${user/@/}\" or .profile.display_name == \"${user/@/}\" or .profile.email == \"${user}\")) | .[0].id")
+        jq -r ".members | map(select(.name == \"${user/@/}\" or .profile.display_name == \"${user/@/}\")) | .[0].id")
 
       echo ${_user}
     ;;

--- a/test/integration/chat.bats
+++ b/test/integration/chat.bats
@@ -14,6 +14,10 @@ load suite
   build/bin/slack chat send 'chat send to direct channel should succeed' @rockymadden
 }
 
+@test 'chat send to direct channel via email should succeed' {
+  build/bin/slack chat send 'chat send to direct channel via email should succeed' github@rockymadden.com
+}
+
 @test 'chat send to invalid channel should fail' {
   run build/bin/slack chat send 'chat send to invalid channel should fail' '#invalid'
   [ ${status} -eq 1 ]


### PR DESCRIPTION
Thanks for the great utility! 

This PR adds support for searching for a user id by their email. Not sure what you want to do about the new integration test but I figured I'd stick in your public github email in it for now. 

I'm seeing a bunch of failures on `make test` even w/o my changes, so I assume there must be extra environment needed to run them cleanly. Please let me know if that's not true! 