### PR TITLE
Added human flag for reminder list and reminder info

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ Usage:
     [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--trace|-x]
 
   slack reminder info [reminder]
-    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--trace|-x]
+    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--human] [--trace|-x]
 
   slack reminder list
-    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]
+    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--human] [--trace|-x]
 
   slack snooze end
     [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]
@@ -363,6 +363,9 @@ $ slack presence active
 ```console
 $ # List reminders:
 $ slack reminder list
+
+$ # List reminders in human readable form via options (no JSON output)
+$ slack reminder list --human
 ```
 
 ### `reminder add`
@@ -370,10 +373,10 @@ $ slack reminder list
 ```console
 $ # Add reminder via prompts:
 $ slack reminder add
-$
+
 $ # Add reminder via arguments:
 $ slack reminder add '@slackbot' 'lunch' 1526995300
-$
+
 $ # Add reminder via options:
 $ slack reminder add --user="@slackbot" --text="lunch" --time=1526995300
 ```
@@ -383,10 +386,10 @@ $ slack reminder add --user="@slackbot" --text="lunch" --time=1526995300
 ```console
 $ # Complete reminder via prompts:
 $ slack reminder complete
-$
+
 $ # Complete reminder via arguments:
 $ slack reminder complete Rm7MGABKT6
-$
+
 $ # Complete reminder via options:
 $ slack reminder complete --reminder="Rm7MGABKT6"
 ```
@@ -396,10 +399,10 @@ $ slack reminder complete --reminder="Rm7MGABKT6"
 ```console
 $ # Complete reminder via prompts:
 $ slack reminder delete
-$
+
 $ # Complete reminder via arguments:
 $ slack reminder delete "Rm7MGABKT6"
-$
+
 $ # Complete reminder via options:
 $ slack reminder delete --reminder="Rm7MGABKT6"
 ```
@@ -409,12 +412,15 @@ $ slack reminder delete --reminder="Rm7MGABKT6"
 ```console
 $ # Info about reminder via prompts:
 $ slack reminder info
-$
+
 $ # Info about reminder via arguments:
 $ slack reminder info "Rm7MGABKT6"
-$
+
 $ # Info about reminder via options:
 $ slack reminder info --reminder="Rm7MGABKT6"
+
+# Info about reminders in human readable form via options (no JSON output)
+$ slack reminder info --human
 ```
 
 ### `presence away`

--- a/src/slack
+++ b/src/slack
@@ -61,6 +61,7 @@ while (( "$#" )); do
     --footer-icon*|-fi*) footericon=${2} ; shift ; shift ;;
     --footer=*) footer=${1/--footer=/''} ; shift ;;
     --footer*|-ft*) footer=${2} ; shift ; shift ;;
+    --human) human=${1/--human=/''} ; shift ;;
     --image=*) image=${1/--image-url=/''} ; shift ;;
     --image*|-im*) image=${2} ; shift ; shift ;;
     --monochrome|-m) monochrome='-M' ; shift ;;
@@ -358,10 +359,10 @@ function help() {
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--trace|-x]'
   echo
   echo "  ${bin} reminder info [reminder]"
-  echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--trace|-x]'
+  echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--reminder|rm] [--human] [--trace|-x]'
   echo
   echo "  ${bin} reminder list"
-  echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
+  echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--human] [--trace|-x]'
   echo
   echo "  ${bin} snooze end"
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
@@ -564,7 +565,8 @@ function reminderinfo() {
       --data-urlencode "reminder=${reminder}" \
       --data-urlencode "token=${token}")
 
-  jqify "${msg}"
+    # If we have a human flag we'll output in a human readable form, otherwise just show the JSON
+  [  -z "$human" ] && jqify "${msg}" || echo ${msg} | jq -r '.reminder | .text as $text | .complete_ts as $completed | .recurring as $recurring | .id as $id | if $recurring == true then "♲ \($text) (id: \($id))" elif $completed == 0 then "✗ \($text) (id: \($id))" else "✓ \($text) (id: \($id))" end'   
 }
 
 function reminderlist() {
@@ -572,7 +574,8 @@ function reminderlist() {
     curl -s -X POST https://slack.com/api/reminders.list \
       --data-urlencode "token=${token}")
 
-  jqify "${msg}"
+  # If we have a human flag we'll output in a human readable form, otherwise just show the JSON
+  [  -z "$human" ] && jqify "${msg}" || echo ${msg} | jq -r '.reminders[] | .text as $text | .complete_ts as $completed | .recurring as $recurring | .id as $id | if $recurring == true then "♲ \($text) (id: \($id))" elif $completed == 0 then "✗ \($text) (id: \($id))" else "✓ \($text) (id: \($id))" end'   
 }
 
 function snoozeend() {


### PR DESCRIPTION
As an addition to the `reminder` functionality there is now a way to output both `reminder list` and `reminder info` in human readable form.

This outputs something along the lines of this:

```console
➜ reminder list --human
♲ My recurring reminder (id: Rm66APGDDV)
♲ Do something when event happens (id: Rm39APGEDF)
♲ Check in with Paul (id: Rm83APGSDR)
✓ I completed something (id: RmJELLGW9J)
✗ This shows a non completed reminder (id: Rm74BJGEKD)
```

• Added `--human` flag to show human readable info about reminders. If flag is not set we default to showing JSON data
• Added docs for --human flag