### PR TITLE
Bail when required executables are missing

### DIFF
--- a/src/slack
+++ b/src/slack
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+for i in curl sed jq grep dirname; do
+  command -v $i >/dev/null 2>&1 || { echo >&2 "Not found: $i. Aborting."; exit 1; }
+done
+
 bindir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 etcdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
I tried to run slack-cli in a minimal environment, and it silently failed
with an exit code, but without printing any errors. I had to look at
the source code to see which executables it requires.

This PR checks if the required executables are all present before doing
anything.