### PR TITLE
Support status expiration dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,12 @@ $ slack status edit --text lunch --emoji :hamburger:
 $
 $ # Edit status via short form options:
 $ slack status edit --tx lunch -em :hamburger:
+$
+$ # Clear status at 09:30 today:
+$ slack status edit -e "$(date -d '09:30' '+%s')" --tx coffee -em :coffee:
+$
+$ # Clear status after 5 minutes:
+$ slack status edit -e +300 --tx "Back in 5" -em :clock1:
 ```
 
 ## Contributors

--- a/src/slack
+++ b/src/slack
@@ -55,6 +55,7 @@ while (( "$#" )); do
     --comment*|-cm*) comment=${2} ; shift ; shift ;;
     --count=*) count=${1/--count=/''} ; shift ;;
     --count|-cn*) count=${2} ; shift ; shift ;;
+    --expire|-e) expire=${2} ; shift ; shift ;;
     --emoji=*) emoji=${1/--emoji=/''} ; shift ;;
     --emoji*|-em*) emoji=${2} ; shift ; shift ;;
     --fields=*) fields=${1/--fields=/''} ; shift ;;
@@ -407,7 +408,7 @@ function help() {
   echo "  ${bin} status clear"
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
   echo
-  echo "  ${bin} status edit [<text> [<emoji>]]"
+  echo "  ${bin} status edit [-e <expire-date>] [<text> [<emoji>]]"
   echo '    [--compact|-c] [--filter|-f <filter>] [--monochrome|-m] [--trace|-x]'
   echo
   echo 'Configuration Commands:'
@@ -647,9 +648,13 @@ function statusclear() {
 }
 
 function statusedit() {
+  if [[ "$expire" =~ ^\+ ]]; then
+    expire="$(( $(date '+%s') + expire ))"
+  fi
+
   local msg=$(\
     curl -s -X POST https://slack.com/api/users.profile.set \
-      --data-urlencode "profile={\"status_text\":\"${text}\", \"status_emoji\":\"${emoji}\"}" \
+      --data-urlencode "profile={\"status_text\":\"${text}\",\"status_expiration\":\"${expire:-0}\",\"status_emoji\":\"${emoji}\"}" \
       --data-urlencode "token=${token}")
 
   jqify "${msg}"


### PR DESCRIPTION
This adds support for the `status_expiration` parameter.

It value is set via the `-e|--expire` flag and can either be:
- an arbitrary UNIX timestamp (default)
- if prefixed with `+`: a number of seconds that will get added to the current
time (eg: +300 for 5 minutes, +3600 for 1 hour)

https://api.slack.com/docs/presence-and-status#user-presence-and-status__custom-status__reading-statuses
