### PR TITLE
add initial replacement for files.upload

### DIFF
--- a/src/slack
+++ b/src/slack
@@ -515,14 +515,23 @@ function fileupload() {
           --data-urlencode "token=${token}")
     ;;
     *)
+      local _length=$(wc -c < ${_file} | xargs)
+      local _get_upload_msg=$(\
+        curl -s -X POST https://slack.com/api/files.getUploadURLExternal \
+          ${_filename:+ --form "filename=${_filename}"} \
+          --form "length=${_length}" \
+          --form "token=${token}")
+      local _upload_url=$(echo ${_get_upload_msg} | jq -r '.upload_url')
+      local _file_id=$(echo ${_get_upload_msg} | jq -r '.file_id')
+      local _upload_post_msg=$(\
+        curl -s -X POST ${_upload_url} \
+          --form "file=@${_file}" \
+          --form "token=${token}")
       local msg=$(\
-        curl -s -X POST https://slack.com/api/files.upload \
+        curl -s -X POST https://slack.com/api/files.completeUploadExternal \
           ${channels:+ --form-string "channels=${channels}"} \
           ${comment:+ --form "initial_comment=${comment}"} \
-          ${_file:+ --form "file=@${_file}"} \
-          ${_filename:+ --form "filename=${_filename}"} \
-          ${filetype:+ --form "filetype=${filetype}"} \
-          ${title:+ --form "title=${title}"} \
+          --form "files=[{'id':'${_file_id}'}]" \
           --form "token=${token}")
     ;;
   esac


### PR DESCRIPTION
This changes only the `files.upload` call that we have been using. It's minimal to begin with. Some of the help documentation likely will have to be updated, as well as some of the additional code in the `fileupload()` function, particularly cases which are potentially no longer relevant.

The new [`files.getUploadURLExternal`](https://api.slack.com/methods/files.getUploadURLExternal) endpoint requires a `length` parameter, which seems quite tricky to implement in a very portable and efficient way. I went with `wc -c < ${_file} | xargs` because it seems to be the most cross-platform, but may be slow.

The new [`files.completeUploadExternal`](https://api.slack.com/methods/files.completeUploadExternal) endpoint only accepts Channel IDs (and not channel names), which is a potentially significant usage change.